### PR TITLE
Fix prettier bracket spacing error

### DIFF
--- a/react-native-template-nativebase-typescript/template/App.tsx
+++ b/react-native-template-nativebase-typescript/template/App.tsx
@@ -25,7 +25,7 @@ import NativeBaseIcon from './src/components/NativeBaseIcon';
 
 // Color Switch Component
 function ToggleDarkMode() {
-  const { colorMode, toggleColorMode } = useColorMode();
+  const {colorMode, toggleColorMode} = useColorMode();
   return (
     <HStack space={2} alignItems="center">
       <Text>Dark</Text>


### PR DESCRIPTION
Use this template to init a new React Native project and found out eslint prettier plugin complain about bracket spacing issue.

Took a look at prettier config and see that we are setting `bracketSpacing: false` so I create a PR to remove the spacing from the template.