### PR TITLE
Fix: remove ts from js next example

### DIFF
--- a/nextjs-with-native-base/.eslintrc.json
+++ b/nextjs-with-native-base/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["next/core-web-vitals", "next/babel"]
+  "extends": ["next/core-web-vitals"]
 }

--- a/nextjs-with-native-base/pages/api/hello.js
+++ b/nextjs-with-native-base/pages/api/hello.js
@@ -1,13 +1,5 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-import type { NextApiRequest, NextApiResponse } from 'next'
 
-type Data = {
-  name: string
-}
-
-export default function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<Data>
-) {
+export default function handler(req, res) {
   res.status(200).json({ name: 'John Doe' })
 }


### PR DESCRIPTION
**Summary of changes:**
* Removes typescript syntax from nextjs vanilla JS template
* Removes `next/babel` from nextjs vanilla JS `.eslintrc.json` file for parity to ts template (and to fix error)